### PR TITLE
Add shared skill levels feature for party members

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.17.2
 
 # Mod Properties
-	mod_version = 1.0.5
+	mod_version = 1.0.6
 	maven_group = net.partyaddon
 	archives_base_name = partyaddon
 

--- a/src/main/java/net/partyaddon/config/PartyAddonConfig.java
+++ b/src/main/java/net/partyaddon/config/PartyAddonConfig.java
@@ -22,4 +22,7 @@ public class PartyAddonConfig implements ConfigData {
     public float hudOpacity = 0.75f; // Client only
     public int hudPosX = 0; // Client only
     public int hudPosY = 0; // Client only
+
+    @Comment("Makes all group members share the same skill levels")
+    public boolean sharedSkillLevels = false;
 }

--- a/src/main/java/net/partyaddon/mixin/LevelHelperMixin.java
+++ b/src/main/java/net/partyaddon/mixin/LevelHelperMixin.java
@@ -1,0 +1,49 @@
+package net.partyaddon.mixin;
+
+import net.levelz.level.LevelManager;
+import net.levelz.level.Skill;
+import net.levelz.util.LevelHelper;
+import net.levelz.util.PacketHelper;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.partyaddon.init.ConfigInit;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Mixin(value = LevelHelper.class)
+public class LevelHelperMixin {
+    @Unique
+    private static final ThreadLocal<Boolean> inMixin = ThreadLocal.withInitial(() -> false);
+
+    @Inject(method = "updateSkill", at = @At("TAIL"), remap = false)
+    private static void updateSkill(ServerPlayerEntity serverPlayerEntity, Skill skill, CallbackInfo ci) {
+        if (!ConfigInit.CONFIG.sharedSkillLevels) return;
+        if (inMixin.get()) return; //prevent recursive inject
+
+        try {
+            inMixin.set(true);
+            MinecraftServer server = serverPlayerEntity.getServer();
+            if (server == null) return;
+
+
+            List<ServerPlayerEntity> players = server.getPlayerManager().getPlayerList().stream().filter(p -> p.getUuid() != serverPlayerEntity.getUuid()).toList();
+            for (ServerPlayerEntity serverPlayerE : players) {
+                for (Skill s : LevelManager.SKILLS.values()) {
+                    LevelHelper.updateSkill(serverPlayerE, s);
+                }
+                PacketHelper.syncEnchantments(serverPlayerE);
+                PacketHelper.updateSkills(serverPlayerE);
+                PacketHelper.updatePlayerSkills(serverPlayerE, null);
+                PacketHelper.updateRestrictions(serverPlayerE);
+            }
+        } finally {
+            inMixin.set(false);
+        }
+    }
+
+}

--- a/src/main/java/net/partyaddon/mixin/LevelManagerMixin.java
+++ b/src/main/java/net/partyaddon/mixin/LevelManagerMixin.java
@@ -1,0 +1,82 @@
+package net.partyaddon.mixin;
+
+import net.levelz.access.LevelManagerAccess;
+import net.levelz.level.LevelManager;
+import net.levelz.level.PlayerSkill;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.partyaddon.access.GroupManagerAccess;
+import net.partyaddon.group.GroupManager;
+import net.partyaddon.init.ConfigInit;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Mixin(value = LevelManager.class, remap = false)
+public abstract class LevelManagerMixin {
+    @Shadow
+    public abstract PlayerEntity getPlayerEntity();
+
+    @Unique
+    private static final ThreadLocal<Boolean> inMixin = ThreadLocal.withInitial(() -> false);
+
+    @Inject(method = "getPlayerSkills", at = @At("RETURN"), cancellable = true, remap = false)
+    private void modifySkillLevel(CallbackInfoReturnable<Map<Integer, PlayerSkill>> cir) {
+        if (!ConfigInit.CONFIG.sharedSkillLevels) return;
+        if (inMixin.get()) return; // prevent recursive inject
+        try {
+            inMixin.set(true);
+            Map<Integer, PlayerSkill> currentPlayerSkills = cir.getReturnValue();
+
+            GroupManager groupManager = ((GroupManagerAccess) (Object) this.getPlayerEntity()).getGroupManager();
+            List<UUID> playerList = groupManager.getGroupPlayerIdList();
+            if (playerList.size() < 2) {
+                return;
+            }
+            if (this.getPlayerEntity().getWorld().isClient()) return;
+            MinecraftServer server = this.getPlayerEntity().getWorld().getServer();
+            if (server == null) return;
+
+
+            for (ServerPlayerEntity serverPlayerEntity : getPlayersFromUUIDs(server, playerList)) {
+                LevelManager otherPlayerManager = ((LevelManagerAccess) serverPlayerEntity).getLevelManager();
+                if (otherPlayerManager == null) continue;
+
+                Map<Integer, PlayerSkill> otherPlayerSkills = otherPlayerManager.getPlayerSkills();
+                for (Map.Entry<Integer, PlayerSkill> entry : otherPlayerSkills.entrySet()) {
+
+                    int currentPlayerLevel = currentPlayerSkills.get(entry.getKey()).getLevel();
+                    int otherPlayerLevel = entry.getValue().getLevel();
+                    if (otherPlayerLevel > currentPlayerLevel) {
+                        currentPlayerSkills.put(entry.getKey(), entry.getValue());
+                    }
+
+                }
+            }
+
+            cir.setReturnValue(currentPlayerSkills); // override return value
+
+        } finally {
+            inMixin.set(false);
+        }
+    }
+
+    @Unique
+    private List<ServerPlayerEntity> getPlayersFromUUIDs(MinecraftServer server, List<UUID> uuids) {
+        return uuids.stream()
+                .map(server.getPlayerManager()::getPlayer)
+                .filter(Objects::nonNull)
+                .filter(player -> !player.getUuid().equals(this.getPlayerEntity().getUuid()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/net/partyaddon/network/PartyAddonServerPacket.java
+++ b/src/main/java/net/partyaddon/network/PartyAddonServerPacket.java
@@ -2,11 +2,13 @@ package net.partyaddon.network;
 
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.levelz.util.PacketHelper;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
 import net.partyaddon.access.GroupManagerAccess;
 import net.partyaddon.group.GroupManager;
+import net.partyaddon.init.ConfigInit;
 import net.partyaddon.network.packet.*;
 import org.jetbrains.annotations.Nullable;
 
@@ -126,6 +128,12 @@ public class PartyAddonServerPacket {
             availablePlayerIdList.add(serverPlayerEntity.getServer().getPlayerManager().getPlayerList().get(i).getUuid());
         }
         availablePlayerIdList.remove(serverPlayerEntity.getUuid());
+        if(ConfigInit.CONFIG.sharedSkillLevels) {
+            //Update group skills
+            for (ServerPlayerEntity serverPlayerE : serverPlayerEntity.getServer().getPlayerManager().getPlayerList()) {
+                PacketHelper.updatePlayerSkills(serverPlayerE, null);
+            }
+        }
         ServerPlayNetworking.send(serverPlayerEntity, new SyncGroupPacket(availablePlayerIdList, groupManager.getStarPlayerIdList(), groupManager.getGroupPlayerIdList(), Optional.ofNullable(groupManager.getGroupLeaderId())));
     }
 

--- a/src/main/resources/partyaddon.mixins.json
+++ b/src/main/resources/partyaddon.mixins.json
@@ -5,15 +5,17 @@
   "compatibilityLevel": "JAVA_21",
   "plugin": "net.partyaddon.mixin.PartyAddonMixinPlugin",
   "mixins": [
+    "ExperienceOrbEntityMixin",
+    "LevelHelperMixin",
+    "LevelManagerMixin",
     "PlayerEntityMixin",
     "ServerPlayerEntityMixin",
-    "ExperienceOrbEntityMixin",
     "compat.LevelExperienceOrbEntityMixin",
     "compat.LevelZServerPlayerEntityMixin"
   ],
   "client": [
-    "compat.GuiMapMixin",
-    "compat.ControlsHandlerMixin"
+    "compat.ControlsHandlerMixin",
+    "compat.GuiMapMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
### Description
This PR introduces a new optional feature that allows party members to share skill levels within a group in the **PartyAddon** for the **LevelZ** Minecraft mod.

---

### Feature Details
- When the feature is **enabled** in the server config, all players in the same group will share their skill levels.  
- The **highest skill level** among the group members for each skill is used as the base level for all members.  
- When a player **joins a group**, they automatically receive the shared skill levels.  
- Party members can then **level up their skills together**, and progress is synchronized across the group.  
- When a player **leaves the group**, they retain the skill levels they had while in the group.

---

### Configuration
- Added a config option: `sharedSkillLevels`  
- **Default:** `false` (disabled) to preserve existing behavior.

---

### Motivation
We wanted to make it easier for players with less playtime to stay engaged and motivated by allowing them to share progress with the group seamlessly.